### PR TITLE
feat: add conditional factory display in OrderHeader component

### DIFF
--- a/src/app/(root)/_components/order-header.tsx
+++ b/src/app/(root)/_components/order-header.tsx
@@ -10,7 +10,6 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import { Progress } from '@/components/ui/progress';
 import { cn, formatDate } from '@/lib/utils';
 import Link from 'next/link';
 import { format, differenceInCalendarDays, isToday } from 'date-fns';
@@ -32,6 +31,7 @@ const formatCurrency = (amount: number) => {
 };
 
 interface OrderHeaderProps {
+  showFactory?: boolean;
   order: {
     id: string;
     orderDate: string;
@@ -62,7 +62,7 @@ interface OrderHeaderProps {
   };
 }
 
-export function OrderHeader({ order }: OrderHeaderProps) {
+export function OrderHeader({ order, showFactory = true }: OrderHeaderProps) {
   return (
     <Card className="mb-6 overflow-hidden border py-2 pt-6">
       {/* Status indicator strip at the top */}
@@ -260,19 +260,21 @@ export function OrderHeader({ order }: OrderHeaderProps) {
             </div>
 
             {/* Factory info */}
-            <div className="bg-card rounded-lg border p-4 shadow-sm transition-all hover:shadow-md">
-              <div className="flex flex-col space-y-3">
-                <span className="text-muted-foreground text-sm font-medium">
-                  Factory
-                </span>
-                <div>
-                  <p className="font-medium">{order.factory?.name}</p>
-                  <p className="text-muted-foreground text-sm">
-                    {order.factory?.owner?.name}
-                  </p>
+            {showFactory && (
+              <div className="bg-card rounded-lg border p-4 shadow-sm transition-all hover:shadow-md">
+                <div className="flex flex-col space-y-3">
+                  <span className="text-muted-foreground text-sm font-medium">
+                    Factory
+                  </span>
+                  <div>
+                    <p className="font-medium">{order.factory?.name}</p>
+                    <p className="text-muted-foreground text-sm">
+                      {order.factory?.owner?.name}
+                    </p>
+                  </div>
                 </div>
               </div>
-            </div>
+            )}
           </div>
 
           {/* Progress section */}
@@ -304,15 +306,18 @@ export function OrderHeader({ order }: OrderHeaderProps) {
                     'Customer address is not available'}
                 </p>
               </div>
-              <div className="bg-card rounded-lg border p-4 shadow-sm">
-                <div className="mb-2 flex items-center gap-2">
-                  <MapPin className="text-muted-foreground h-4 w-4" />
-                  <span className="text-sm font-medium">Factory Address</span>
+              {showFactory && (
+                <div className="bg-card rounded-lg border p-4 shadow-sm">
+                  <div className="mb-2 flex items-center gap-2">
+                    <MapPin className="text-muted-foreground h-4 w-4" />
+                    <span className="text-sm font-medium">Factory Address</span>
+                  </div>
+                  <p className="text-sm">
+                    {order?.factoryAddress ||
+                      'Factory address is not available'}
+                  </p>
                 </div>
-                <p className="text-sm">
-                  {order?.factoryAddress || 'Factory address is not available'}
-                </p>
-              </div>
+              )}
             </div>
           )}
         </div>

--- a/src/app/(root)/factory/orders/[id]/page.tsx
+++ b/src/app/(root)/factory/orders/[id]/page.tsx
@@ -1294,9 +1294,6 @@ export default function FactoryOrderDetailsPage() {
                                     check.failedEvaluationCriteria.length >
                                       0 && (
                                       <div className="mt-2">
-                                        <h4 className="mb-2 text-sm font-medium text-red-600 dark:text-red-400">
-                                          Failed Criteria:
-                                        </h4>
                                         <div className="grid gap-2">
                                           {check.failedEvaluationCriteria.map(
                                             (failed, failedIdx) => (

--- a/src/app/(root)/my-order/[id]/page.tsx
+++ b/src/app/(root)/my-order/[id]/page.tsx
@@ -311,6 +311,7 @@ export default function OrderDetailsPage() {
       {/* Order Header */}
       {order && (
         <OrderHeader
+          showFactory={false}
           order={{
             id: order.id,
             orderDate: order.orderDate || '',


### PR DESCRIPTION
- Introduced a new prop `showFactory` to the OrderHeader component to control the visibility of factory information.
- Updated the rendering logic to conditionally display factory details and address based on the `showFactory` prop, enhancing flexibility for different order views.